### PR TITLE
Add font size classes to typography.css

### DIFF
--- a/src/css/typography.css
+++ b/src/css/typography.css
@@ -1,4 +1,19 @@
-/* add classes here */
+.font-small {
+    font-size: 12px;
+}
+
+.font-medium {
+    font-size: 16px;
+}
+
+.font-large {
+    font-size: 20px;
+}
+
+.font-xlarge {
+    font-size: 24px;
+}
+
 
 
 


### PR DESCRIPTION
This pull request addresses issue by adding font size classes to the `typography.css` file.
- Added font size classes: `.font-small`, `.font-medium`, `.font-large`, and `.font-xlarge` to the `typography.css` file.
